### PR TITLE
qrtool: Fix `extract_dir`

### DIFF
--- a/bucket/qrtool.json
+++ b/bucket/qrtool.json
@@ -5,12 +5,13 @@
     "license": "Apache-2.0|MIT",
     "url": "https://github.com/sorairolake/qrtool/releases/download/v0.10.1/qrtool-v0.10.1-x86_64-pc-windows-msvc.7z",
     "hash": "d231b0b5635ba69fba715ee4e3bc4fd56764ca4a03a74762d9e77106b7a45384",
-    "extract_dir": "qrtool-v$version-x86_64-pc-windows-msvc",
+    "extract_dir": "qrtool-v0.10.1-x86_64-pc-windows-msvc",
     "bin": "qrtool.exe",
     "checkver": {
         "github": "https://github.com/sorairolake/qrtool"
     },
     "autoupdate": {
-        "url": "https://github.com/sorairolake/qrtool/releases/download/v$version/qrtool-v$version-x86_64-pc-windows-msvc.7z"
+        "url": "https://github.com/sorairolake/qrtool/releases/download/v$version/qrtool-v$version-x86_64-pc-windows-msvc.7z",
+        "extract_dir": "qrtool-v$version-x86_64-pc-windows-msvc"
     }
 }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
